### PR TITLE
fix: resolve `Float128` dtype error on Windows

### DIFF
--- a/gwas_sumstats_tools/schema/data_table.py
+++ b/gwas_sumstats_tools/schema/data_table.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from pandera import Column, DataFrameSchema, Check
 from pandera.dtypes import Float128
 
+import platform
 
 class SumStatsSchema:
     """Pandera DataFrameSchema interface for
@@ -38,7 +39,7 @@ class SumStatsSchema:
             ])
         }
     PVALUE_FIELD_DEFINITIONS = {
-        'p_value': Column(Float128, [
+        'p_value': Column(float if platform.system() == "Windows" else Float128, [
             Check.in_range(0, 1,
                            include_min=True,
                            error="Must be a value between 0 and 1, inclusive of 0")


### PR DESCRIPTION
### Summary

This PR addresses the `TypeError` associated with the `Float128` data type that Windows users encountered when running `gwas-ssf` without any options or files. The error was due to the lack of consistent support for the `Float128` data type across platforms.

### Changes

- Introduced a platform check to conditionally set the `p_value` column data type to `Float128` for non-Windows platforms and `Float64` for Windows.
- Updated the `SumStatsSchema` class in `gwas_sumstats_tools/schema/data_table.py` to reflect the above changes.

### Testing

The changes were tested on both Windows and macOS platforms:

**Test Steps:**
1. Set up a fresh environment using Miniconda3 with Python 3.11.4.
2. Cloned the repository and checked out the `15-typeerror-dtype-float128` branch.
3. Installed the project dependencies using `poetry install`.
4. Ran the `gwas-ssf` command without options or files.

On both platforms, the previously reported error was not observed, confirming that the fix works as intended.

Resolves #15.
