### PR TITLE
bugfix: remove extra quote and use `get()` instead of `[]` in case config_dict is empty

### DIFF
--- a/gwas_sumstats_tools/format.py
+++ b/gwas_sumstats_tools/format.py
@@ -45,7 +45,7 @@ class Formatter:
         elif analysis_software in pre_defined_configure.keys():
             self.config_dict = pre_defined_configure[analysis_software]
         else:
-            self.config_dict = config_dict
+            self.config_dict = config_dict or {}
 
         self.data_outfile = Path(
             self._set_data_outfile_name() if not data_outfile else data_outfile

--- a/gwas_sumstats_tools/format.py
+++ b/gwas_sumstats_tools/format.py
@@ -119,7 +119,7 @@ class Formatter:
                 )
         elif self.config_dict["fileConfig"]["outputSuffix"]:
             self.data_outfile = append_to_path(
-                    self.data_infile, self.config_dict["fileConfig"]["outFileSuffix""]
+                    self.data_infile, self.config_dict["fileConfig"]["outFileSuffix"]
                 )
         else:
             self.data_outfile = append_to_path(

--- a/gwas_sumstats_tools/format.py
+++ b/gwas_sumstats_tools/format.py
@@ -117,7 +117,7 @@ class Formatter:
                 self.data_outfile = append_to_path(
                     self.data_infile, "-FORMATTED.tsv.gz"
                 )
-        elif self.config_dict["fileConfig"]["outputSuffix"]:
+        elif self.config_dict.get("fileConfig", {}).get("outFileSuffix", None):
             self.data_outfile = append_to_path(
                     self.data_infile, self.config_dict["fileConfig"]["outFileSuffix"]
                 )


### PR DESCRIPTION
This PR fixes two issues we noticed when running `poetry run pytest`.
Both issues were in `gwas_sumstats_tools/format.py`

1. Remove extra quotation causing an error.
2. Fix one arm of a conditional statement that would throw a KeyError when config_dict was empty. In particular, when you try to access a value in a Python dictionary using `[<key>]` and the key is missing, it will cause a KeyError. So we fix this by using the `get(<key>)` function instead.