### PR TITLE
return the index to show the position of invalid row in the original file

### DIFF
--- a/gwas_sumstats_tools/interfaces/data_table.py
+++ b/gwas_sumstats_tools/interfaces/data_table.py
@@ -313,7 +313,7 @@ class SumStatsTable:
         df = pd.DataFrame()
         if skiprows:
             # Keep the header row (0) and skip the nrows previous step already read.
-            skip = range(1, skiprows + 1) if isinstance(skiprows, int) else skiprows
+            skip = range(1, skiprows + 1) 
         else:
             skip = None
         if self.is_table_content():

--- a/gwas_sumstats_tools/interfaces/data_table.py
+++ b/gwas_sumstats_tools/interfaces/data_table.py
@@ -311,7 +311,7 @@ class SumStatsTable:
             Pandas dataframe or iter
         """
         df = pd.DataFrame()
-        if skiprows:
+        if skiprows is not None:
             # Keep the header row (0) and skip the nrows previous step already read.
             skip = list(range(1, skiprows + 1))
         else:

--- a/gwas_sumstats_tools/interfaces/data_table.py
+++ b/gwas_sumstats_tools/interfaces/data_table.py
@@ -311,7 +311,11 @@ class SumStatsTable:
             Pandas dataframe or iter
         """
         df = pd.DataFrame()
-        skip = range(1, skiprows) if skiprows else None
+        if skiprows:
+            # Skip the header row (0) and the requested number of data rows.
+            skip = range(1, skiprows + 1) if isinstance(skiprows, int) else skiprows
+        else:
+            skip = None
         if self.is_table_content():
             df = pd.read_table(self.filename,
                                sep=self.delimiter,

--- a/gwas_sumstats_tools/interfaces/data_table.py
+++ b/gwas_sumstats_tools/interfaces/data_table.py
@@ -313,7 +313,7 @@ class SumStatsTable:
         df = pd.DataFrame()
         if skiprows:
             # Keep the header row (0) and skip the nrows previous step already read.
-            skip = range(1, skiprows + 1) 
+            skip = list(range(1, skiprows + 1))
         else:
             skip = None
         if self.is_table_content():

--- a/gwas_sumstats_tools/interfaces/data_table.py
+++ b/gwas_sumstats_tools/interfaces/data_table.py
@@ -312,7 +312,7 @@ class SumStatsTable:
         """
         df = pd.DataFrame()
         if skiprows:
-            # Skip the header row (0) and the requested number of data rows.
+            # Keep the header row (0) and skip the nrows previous step already read.
             skip = range(1, skiprows + 1) if isinstance(skiprows, int) else skiprows
         else:
             skip = None

--- a/gwas_sumstats_tools/validate.py
+++ b/gwas_sumstats_tools/validate.py
@@ -48,12 +48,12 @@ class Validator(SumStatsTable):
         """
         print("Validating extension")
         self.valid, message = self._validate_file_ext()
-        """
+
         if self.valid:
             print("--> [green]Ok[/green]")
             print("Validating column order")
             self.valid, message = self._validate_field_order()
-        """
+
         if self.valid:
             print("--> [green]Ok[/green]")
             print(f"Validating the chromosomes")
@@ -128,16 +128,20 @@ class Validator(SumStatsTable):
             chr_column=etl.values(table,'chromosome')
             
             unique_chr = set(chr_column)
-            valid_chromosomes = set(map(str, range(1, 23)))
+            autosomes_chromosomes=set(map(str, range(1, 23)))
+            optional_chromosomes = set(map(str, range(23, 26)))
             
-            missing_chromosomes=sorted(valid_chromosomes-unique_chr, key=int)
-
-        if len(missing_chromosomes)>0:
-
-            return False, (f"Chromosome column mising values:{missing_chromosomes}")
-        
-        return True, "This file contains all autosomes: chromosomes 1-22."
-
+            missing_autosomes = sorted(autosomes_chromosomes - unique_chr, key=int)
+            missing_optional = sorted(optional_chromosomes - unique_chr, key=int)
+            
+            if unique_chr == {"23"}:
+                return True, "This file only contains chromosome X."
+            if missing_autosomes:
+                return False, f"Chromosome column missing values: {missing_autosomes}"
+            if missing_optional:
+                return True, f"All autosomes exist. Optional chromosomes {missing_optional} do not exist."
+            
+            return True, "All chromosomes, including X, Y, and MT, exist."
     
     def _validate_df(self,
                      dataframe: pd.DataFrame,

--- a/gwas_sumstats_tools/validate.py
+++ b/gwas_sumstats_tools/validate.py
@@ -48,10 +48,16 @@ class Validator(SumStatsTable):
         """
         print("Validating extension")
         self.valid, message = self._validate_file_ext()
+        """
         if self.valid:
             print("--> [green]Ok[/green]")
             print("Validating column order")
             self.valid, message = self._validate_field_order()
+        """
+        if self.valid:
+            print("--> [green]Ok[/green]")
+            print(f"Validating the chromosomes")
+            self.valid, message = self._validate_chromosomes()
         if self.valid:
             print("--> [green]Ok[/green]")
             nrows = max(self.sample_size, self.minimum_rows)
@@ -105,6 +111,34 @@ class Validator(SumStatsTable):
                        f"Headers required: {required_order}")
         return valid, message
 
+    def _validate_chromosomes(self) -> tuple[bool, str]:
+        """Check if the chromosome column contains only integers 1-22.
+        
+        Args:
+        sself.sumstats: petl read input sumstat files
+        
+        Returns:
+        tuple[bool, str]: Validation status and error message.
+          """
+    
+        if "chromosome" not in self.header():
+            return False, "Chromosome column is missing from the input file."
+        else:
+            table=etl.convert(self.sumstats,'chromosome', str)
+            chr_column=etl.values(table,'chromosome')
+            
+            unique_chr = set(chr_column)
+            valid_chromosomes = set(map(str, range(1, 23)))
+            
+            missing_chromosomes=sorted(valid_chromosomes-unique_chr, key=int)
+
+        if len(missing_chromosomes)>0:
+
+            return False, (f"Chromosome column mising values:{missing_chromosomes}")
+        
+        return True, "This file contains all autosomes: chromosomes 1-22."
+
+    
     def _validate_df(self,
                      dataframe: pd.DataFrame,
                      message: str = "Data table is invalid") -> tuple[bool, str]:

--- a/gwas_sumstats_tools/validate.py
+++ b/gwas_sumstats_tools/validate.py
@@ -46,31 +46,32 @@ class Validator(SumStatsTable):
         Returns:
             Validation status, message
         """
-        print("Validating extension")
+        print("Validating extension...")
         self.valid, message = self._validate_file_ext()
 
         if self.valid:
             print("--> [green]Ok[/green]")
-            print("Validating column order")
+            print("Validating column order...")
             self.valid, message = self._validate_field_order()
 
         if self.valid:
             print("--> [green]Ok[/green]")
-            print(f"Validating the chromosomes")
+            print(f"Validating the chromosomes...")
             self.valid, message = self._validate_chromosomes()
+            print(f"    [dim][grey](note: {message})[/grey][/dim]") 
         if self.valid:
             print("--> [green]Ok[/green]")
             nrows = max(self.sample_size, self.minimum_rows)
-            print("Validating minimum row count")
+            print("Validating minimum row count...")
             sample_df = self.as_pd_df(nrows=nrows)
             self.valid, message = self._minrow_check(df=sample_df)
         if self.valid:
             print("--> [green]Ok[/green]")
-            print(f"Validating the first {nrows} rows")
+            print(f"Validating the first {nrows} rows...")
             self.valid, message = self._validate_df(sample_df)
         if self.valid:
             print("--> [green]Ok[/green]")
-            print("Validating the rest of the file")
+            print("Validating the rest of the file...")
             try:
                 df_iter = self.as_pd_df(chunksize=self.chunksize,
                                         skiprows=nrows)

--- a/gwas_sumstats_tools/validate.py
+++ b/gwas_sumstats_tools/validate.py
@@ -64,6 +64,7 @@ class Validator(SumStatsTable):
             nrows = max(self.sample_size, self.minimum_rows)
             print("Validating minimum row count...")
             sample_df = self.as_pd_df(nrows=nrows)
+            offset = len(sample_df)
             self.valid, message = self._minrow_check(df=sample_df)
         if self.valid:
             print("--> [green]Ok[/green]")
@@ -75,8 +76,13 @@ class Validator(SumStatsTable):
             try:
                 df_iter = self.as_pd_df(chunksize=self.chunksize,
                                         skiprows=nrows)
+
+                offset = nrows + 2  # +2 for header and 0-indexing
                 for df in df_iter:
+                    df = df.reset_index(drop=True)
+                    df.index += offset
                     self.valid, message = self._validate_df(df)
+                    offset += len(df)
                     if self.valid is False:
                         break
             except pd.errors.EmptyDataError:
@@ -165,7 +171,16 @@ class Validator(SumStatsTable):
             self.errors_table = None
             self.primary_error_type = None
         except errors.SchemaErrors as err:
-            self.errors_table = etl.fromdataframe(err.failure_cases) if len(err.failure_cases) > 0 else None
+            failure_cases = err.failure_cases
+            if len(failure_cases) > 0:
+                # Sort primarily by error type (schema context), then by row index and column
+                failure_cases = failure_cases.sort_values(
+                    by=["schema_context", "index", "column"],
+                    kind="mergesort"
+                )
+                self.errors_table = etl.fromdataframe(failure_cases)
+            else:
+                self.errors_table = None
             valid = False
         return valid, message
 

--- a/gwas_sumstats_tools/validate.py
+++ b/gwas_sumstats_tools/validate.py
@@ -64,7 +64,6 @@ class Validator(SumStatsTable):
             nrows = max(self.sample_size, self.minimum_rows)
             print("Validating minimum row count...")
             sample_df = self.as_pd_df(nrows=nrows)
-            offset = len(sample_df)
             self.valid, message = self._minrow_check(df=sample_df)
         if self.valid:
             print("--> [green]Ok[/green]")


### PR DESCRIPTION
The input file is read by chunks, and the index only shows the position within the chunk. This improvement allows the index to show the position in the raw file, and users can check the specific rows by `sed -n "$((n-5)),$((n+5))p" file.tsv`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row-skipping during data import so integer skip parameters now preserve the header row and exclude the intended rows.
  * Improved chunked validation: per-chunk indexing now aligns with the full file, and validation failure reports are deterministically ordered before presenting error tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->