### PR TITLE
Change tag pattern to match all tags in workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "*"
 
 jobs:
   test:


### PR DESCRIPTION
gwas-sumstats-tools version does not have "v" at the beginning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation trigger to process all repository tags instead of specifically versioned ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->