### PR TITLE
add z-score 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "**"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group dev --frozen
+
+      - name: Run tests
+        run: uv run pytest -v

--- a/docs/gwas-sumstats-tools-doc/CLI_format.md
+++ b/docs/gwas-sumstats-tools-doc/CLI_format.md
@@ -114,6 +114,8 @@ Each input file in the list will be submitted as an independent job to run, allo
 ## Default Functions
 Beyond formatting the input file according to the configuration file, the format tool also applies several default settings to every summary statistic:
 
+`z-score` is accepted as a fallback effect size type. Where possible, submit `beta`, `odds_ratio`, or `hazard_ratio` instead.
+
 1. Reorder the mandatory columns in your dataset to match the GWAS-SSF specified sequence: 
 ```text
 chromosome, base_pair_location, effect_allele, other_allele, effect (beta/odds ratio/hazard ratio/z-score), standard_error, effect_allele_frequency, pval (or negativelog10Pvalue). For z-score files, standard_error remains in this position and is populated with #NA.

--- a/docs/gwas-sumstats-tools-doc/CLI_format.md
+++ b/docs/gwas-sumstats-tools-doc/CLI_format.md
@@ -116,7 +116,7 @@ Beyond formatting the input file according to the configuration file, the format
 
 1. Reorder the mandatory columns in your dataset to match the GWAS-SSF specified sequence: 
 ```text
-chromosome, base_pair_location, effect_allele, other_allele, effect (beta/odds ratio/hazard ratio/z-score), standard_error, effect_allele_frequency, pval (or negativelog10Pvalue). For z-score files, omit standard_error.
+chromosome, base_pair_location, effect_allele, other_allele, effect (beta/odds ratio/hazard ratio/z-score), standard_error, effect_allele_frequency, pval (or negativelog10Pvalue). For z-score files, standard_error remains in this position and is populated with #NA.
 ```
 Any additional columns will remain in their original input order.
 

--- a/docs/gwas-sumstats-tools-doc/CLI_format.md
+++ b/docs/gwas-sumstats-tools-doc/CLI_format.md
@@ -116,7 +116,7 @@ Beyond formatting the input file according to the configuration file, the format
 
 1. Reorder the mandatory columns in your dataset to match the GWAS-SSF specified sequence: 
 ```text
-chromosome, base_pair_location, effect_allele, other_allele, effect (beta/odds ratio/hazard ratio), standard_error, effect_allele_frequency, pval (or negativelog10Pvalue). 
+chromosome, base_pair_location, effect_allele, other_allele, effect (beta/odds ratio/hazard ratio/z-score), standard_error, effect_allele_frequency, pval (or negativelog10Pvalue). For z-score files, omit standard_error.
 ```
 Any additional columns will remain in their original input order.
 

--- a/docs/gwas-sumstats-tools-doc/CLI_validate.md
+++ b/docs/gwas-sumstats-tools-doc/CLI_validate.md
@@ -15,6 +15,9 @@ The validation tool is crafted to verify if the selected summary statistics file
 |`--chunksize`|`-s`|int|1,000,000|Number of rows to store in memory at once. Increase this number for more speed at the cost of more memory. Decrease to save memory, at the cost of speed|
 |`--infer-from-metadata`|`-i`|Boolean|False|Infer validation options from the metadata file `<filename>-meta.yaml`. E.g. fields for analysis software and negative log10 p-values affect the data validation behaviour.|
 
+## Effect Size Fields
+`z-score` is accepted as a fallback effect size type. Where possible, submit `beta`, `odds_ratio`, or `hazard_ratio` instead. When `z-score` is used, `standard_error` remains in the standard column position and must be populated with `#NA`.
+
 
 ## Examples
 Suppose you have a file named `GCST12345_formatted.tsv` that needs to be validated to see if it adheres to the GWAS-SSF schema.

--- a/docs/gwas-sumstats-tools-doc/edit_config.md
+++ b/docs/gwas-sumstats-tools-doc/edit_config.md
@@ -260,7 +260,7 @@ Extract only the rsID portion from a combined `rsid` column and rename the colum
 Beyond the configuration file, the formatter automatically applies these steps to every file:
 
 1. **Reorder mandatory columns** to match the GWAS-SSF sequence:
-   `chromosome` → `base_pair_location` → `effect_allele` → `other_allele` → `effect` (beta / odds ratio / hazard ratio / `z-score`) → `standard_error` → `effect_allele_frequency` → `p_value` (or `neg_log_10_p_value`). For `z-score` files, omit `standard_error`.
+   `chromosome` → `base_pair_location` → `effect_allele` → `other_allele` → `effect` (beta / odds ratio / hazard ratio / `z-score`) → `standard_error` → `effect_allele_frequency` → `p_value` (or `neg_log_10_p_value`). For `z-score` files, `standard_error` remains in this position and is populated with `#NA`.
    Any extra columns follow in their original order.
 
 2. **Fill missing mandatory columns** — if a required column is absent, it is added and filled with `#NA`.

--- a/docs/gwas-sumstats-tools-doc/edit_config.md
+++ b/docs/gwas-sumstats-tools-doc/edit_config.md
@@ -260,7 +260,7 @@ Extract only the rsID portion from a combined `rsid` column and rename the colum
 Beyond the configuration file, the formatter automatically applies these steps to every file:
 
 1. **Reorder mandatory columns** to match the GWAS-SSF sequence:
-   `chromosome` → `base_pair_location` → `effect_allele` → `other_allele` → `effect` (beta / odds ratio / hazard ratio) → `standard_error` → `effect_allele_frequency` → `p_value` (or `neg_log_10_p_value`).
+   `chromosome` → `base_pair_location` → `effect_allele` → `other_allele` → `effect` (beta / odds ratio / hazard ratio / `z-score`) → `standard_error` → `effect_allele_frequency` → `p_value` (or `neg_log_10_p_value`). For `z-score` files, omit `standard_error`.
    Any extra columns follow in their original order.
 
 2. **Fill missing mandatory columns** — if a required column is absent, it is added and filled with `#NA`.

--- a/docs/gwas-sumstats-tools-doc/edit_config.md
+++ b/docs/gwas-sumstats-tools-doc/edit_config.md
@@ -259,6 +259,8 @@ Extract only the rsID portion from a combined `rsid` column and rename the colum
 
 Beyond the configuration file, the formatter automatically applies these steps to every file:
 
+`z-score` is accepted as a fallback effect size type. Where possible, submit `beta`, `odds_ratio`, or `hazard_ratio` instead.
+
 1. **Reorder mandatory columns** to match the GWAS-SSF sequence:
    `chromosome` → `base_pair_location` → `effect_allele` → `other_allele` → `effect` (beta / odds ratio / hazard ratio / `z-score`) → `standard_error` → `effect_allele_frequency` → `p_value` (or `neg_log_10_p_value`). For `z-score` files, `standard_error` remains in this position and is populated with `#NA`.
    Any extra columns follow in their original order.

--- a/src/gwas_sumstats_tools/constants.py
+++ b/src/gwas_sumstats_tools/constants.py
@@ -51,6 +51,11 @@ GENOME_ASSEMBLY_MAPPINGS: Final[dict[str, GenomeAssembly]] = {
 
 GWAS_SSF_VERSION: Final[str] = "1.0"
 
+Z_SCORE_FALLBACK_WARNING: Final[str] = (
+    "WARNING: z-score is accepted only as a fallback effect size. "
+    "Please submit beta, odds ratio (OR), or hazard ratio where available."
+)
+
 # file_type alias -> standard value mapping (keys are lowercased/normalised for lookup)
 FILE_TYPE_MAPPINGS: Final[dict[str, str]] = {
     # pre-GWAS-SSF variants

--- a/src/gwas_sumstats_tools/format.py
+++ b/src/gwas_sumstats_tools/format.py
@@ -458,7 +458,12 @@ class Formatter:
                 chunk = self._pd_apply_edits(chunk, edit_config)
                 chunk = self._pd_normalise(chunk, self.na)
                 if 'z-score' in chunk.columns:
-                    chunk['standard_error'] = '#NA'
+                    # Only blank standard_error when z-score is the effective
+                    # effect field. If a real effect field is present, z-score
+                    # is just an extra column and its standard_error is kept.
+                    if not any(e in chunk.columns
+                               for e in ('beta', 'odds_ratio', 'hazard_ratio')):
+                        chunk['standard_error'] = '#NA'
                     if not z_score_warning_printed:
                         warn_z_score_fallback()
                         z_score_warning_printed = True

--- a/src/gwas_sumstats_tools/format.py
+++ b/src/gwas_sumstats_tools/format.py
@@ -399,16 +399,10 @@ class Formatter:
     @staticmethod
     def _pd_column_order(cols: list) -> list:
         col_set = set(cols)
-        required_fields = list(SumStatsTable.FIELDS_REQUIRED)
-        if 'z-score' in col_set:
-            required_fields.remove('standard_error')
-        all_required = list(SumStatsTable.FIELDS_REQUIRED)
-        if 'z-score' in col_set:
-            all_required.remove('standard_error')
-        all_std = set(all_required +
+        all_std = set(list(SumStatsTable.FIELDS_REQUIRED) +
                       list(SumStatsTable.FIELDS_EFFECT) +
                       list(SumStatsTable.FIELDS_OPTIONAL))
-        order  = [h for h in required_fields if h in col_set]
+        order  = [h for h in SumStatsTable.FIELDS_REQUIRED if h in col_set]
         order += [h for h in SumStatsTable.FIELDS_OPTIONAL if h in col_set]
         order += [h for h in cols if h not in all_std]
         for eff in SumStatsTable.FIELDS_EFFECT:
@@ -454,6 +448,8 @@ class Formatter:
                 chunk = self._pd_apply_splits(chunk, split_config)
                 chunk = self._pd_apply_edits(chunk, edit_config)
                 chunk = self._pd_normalise(chunk, self.na)
+                if 'z-score' in chunk.columns:
+                    chunk['standard_error'] = '#NA'
 
                 if convert_neg_log and 'p_value' in chunk.columns:
                     def _safe_neg_log(x):
@@ -464,10 +460,7 @@ class Formatter:
                     chunk['p_value'] = chunk['p_value'].map(_safe_neg_log)
 
                 if first_chunk:
-                    required_fields = list(SumStatsTable.FIELDS_REQUIRED)
-                    if 'z-score' in chunk.columns:
-                        required_fields.remove('standard_error')
-                    for h in required_fields:
+                    for h in SumStatsTable.FIELDS_REQUIRED:
                         if h not in chunk.columns:
                             chunk[h] = '#NA'
                     if not any(e in chunk.columns for e in SumStatsTable.FIELDS_EFFECT):

--- a/src/gwas_sumstats_tools/format.py
+++ b/src/gwas_sumstats_tools/format.py
@@ -16,6 +16,7 @@ from gwas_sumstats_tools.utils import (
     parse_accession_id,
     append_to_path,
     exit_if_no_data,
+    warn_z_score_fallback,
 )
 
 
@@ -99,6 +100,7 @@ class Formatter:
         test_edit_table=self.edit(config=self.config_dict,data=test_split_table)
         test_filled_table=test_edit_table.normalise_missing_values(na_value=self.na)
         test_formatted_data=test_filled_table.map_header()
+        self._warn_if_z_score_fields(test_formatted_data.header())
 
         if self.config_dict["fileConfig"]["convertNegLog10Pvalue"]==True:
             test_formatted_data=test_formatted_data.convert_neg_log10_pvalue()
@@ -279,6 +281,7 @@ class Formatter:
         edit_table=self.edit(config=self.config_dict,data=split_table)
         filled_table=edit_table.normalise_missing_values(na_value=self.na)
         formatted_data=filled_table.map_header()
+        self._warn_if_z_score_fields(formatted_data.header())
 
         if self.config_dict["fileConfig"]["convertNegLog10Pvalue"]==True:
             formatted_data=formatted_data.convert_neg_log10_pvalue()
@@ -347,6 +350,11 @@ class Formatter:
         self._apply_pandas(self.data_outfile)
 
     # ── pandas-based apply pipeline ───────────────────────────────────────────
+
+    @staticmethod
+    def _warn_if_z_score_fields(fields: list | tuple) -> None:
+        if 'z-score' in fields:
+            warn_z_score_fallback()
 
     @staticmethod
     def _pd_apply_splits(df: pd.DataFrame, split_config: list) -> pd.DataFrame:
@@ -438,6 +446,7 @@ class Formatter:
         open_out    = gzip.open if output_path.endswith('.gz') else open
         first_chunk = True
         final_cols  = None
+        z_score_warning_printed = False
         t0          = time.time()
 
         with open_out(output_path, 'wt', encoding='utf-8') as out:
@@ -450,6 +459,9 @@ class Formatter:
                 chunk = self._pd_normalise(chunk, self.na)
                 if 'z-score' in chunk.columns:
                     chunk['standard_error'] = '#NA'
+                    if not z_score_warning_printed:
+                        warn_z_score_fallback()
+                        z_score_warning_printed = True
 
                 if convert_neg_log and 'p_value' in chunk.columns:
                     def _safe_neg_log(x):
@@ -604,6 +616,7 @@ def format(
              print("[bold]\n-------- SUMSTATS DATA --------\n[/bold]")
              print(formatter.data.sumstats)
              formatter.data.reformat_header() 
+             Formatter._warn_if_z_score_fields(formatter.data.header())
              formatter.data.normalise_missing_values(None)
              print("[bold]\n-------- REFORMATTED DATA --------\n[/bold]")
              print(formatter.data.sumstats)

--- a/src/gwas_sumstats_tools/format.py
+++ b/src/gwas_sumstats_tools/format.py
@@ -399,10 +399,16 @@ class Formatter:
     @staticmethod
     def _pd_column_order(cols: list) -> list:
         col_set = set(cols)
-        all_std = set(list(SumStatsTable.FIELDS_REQUIRED) +
+        required_fields = list(SumStatsTable.FIELDS_REQUIRED)
+        if 'z-score' in col_set:
+            required_fields.remove('standard_error')
+        all_required = list(SumStatsTable.FIELDS_REQUIRED)
+        if 'z-score' in col_set:
+            all_required.remove('standard_error')
+        all_std = set(all_required +
                       list(SumStatsTable.FIELDS_EFFECT) +
                       list(SumStatsTable.FIELDS_OPTIONAL))
-        order  = [h for h in SumStatsTable.FIELDS_REQUIRED if h in col_set]
+        order  = [h for h in required_fields if h in col_set]
         order += [h for h in SumStatsTable.FIELDS_OPTIONAL if h in col_set]
         order += [h for h in cols if h not in all_std]
         for eff in SumStatsTable.FIELDS_EFFECT:
@@ -458,7 +464,10 @@ class Formatter:
                     chunk['p_value'] = chunk['p_value'].map(_safe_neg_log)
 
                 if first_chunk:
-                    for h in SumStatsTable.FIELDS_REQUIRED:
+                    required_fields = list(SumStatsTable.FIELDS_REQUIRED)
+                    if 'z-score' in chunk.columns:
+                        required_fields.remove('standard_error')
+                    for h in required_fields:
                         if h not in chunk.columns:
                             chunk[h] = '#NA'
                     if not any(e in chunk.columns for e in SumStatsTable.FIELDS_EFFECT):

--- a/src/gwas_sumstats_tools/interfaces/data_table.py
+++ b/src/gwas_sumstats_tools/interfaces/data_table.py
@@ -179,7 +179,14 @@ class SumStatsTable:
         return missing_headers
 
     def _normalise_z_score_standard_error(self) -> etl.Table:
-        if "z-score" in self.header() and "standard_error" in self.header():
+        # Only blank the standard_error when z-score is the effective effect
+        # field. When a real effect field (beta/odds_ratio/hazard_ratio) is
+        # present, z-score is just an extra column and its standard_error must
+        # be preserved.
+        if (
+            self._effect_field_in_header() == "z-score"
+            and "standard_error" in self.header()
+        ):
             self.sumstats = etl.convert(self.sumstats, "standard_error", lambda _: "#NA")
         return self.sumstats
 

--- a/src/gwas_sumstats_tools/interfaces/data_table.py
+++ b/src/gwas_sumstats_tools/interfaces/data_table.py
@@ -29,7 +29,8 @@ class SumStatsTable:
     FIELDS_REQUIRED = ("chromosome", "base_pair_location", "effect_allele",
                        "other_allele", "standard_error",
                        "effect_allele_frequency", "p_value")
-    FIELDS_EFFECT = ("beta", "odds_ratio", "hazard_ratio")
+    FIELDS_EFFECT = ("beta", "odds_ratio", "hazard_ratio", "z-score")
+    FIELDS_PVALUE = ("p_value", "neg_log_10_p_value")
     FIELDS_OPTIONAL = ("variant_id", "rsid", "info", "ci_upper", "ci_lower", "ref_allele")
 
     def __init__(self, sumstats_file: Path, delimiter: str = None, removecomments: str = None) -> None:
@@ -170,10 +171,19 @@ class SumStatsTable:
         Returns:
             set of missing headers
         """
-        missing_headers = set(self.FIELDS_REQUIRED) - set(self.header())
+        required_fields = set(self.FIELDS_REQUIRED)
+        if "z-score" in self.header():
+            required_fields.discard("standard_error")
+        missing_headers = required_fields - set(self.header())
         if set(self.FIELDS_EFFECT).isdisjoint(set(self.header())):
             missing_headers.add("beta")
         return missing_headers
+
+    def _effect_field_in_header(self) -> Union[str, None]:
+        for field in self.FIELDS_EFFECT:
+            if field in self.header():
+                return field
+        return None
 
     def _set_header_order(self) -> list:
         """Set the header order
@@ -181,23 +191,23 @@ class SumStatsTable:
         Returns:
             List of headers in standard order
         """
+        effect_field = self._effect_field_in_header()
+        required_fields = [h for h in self.FIELDS_REQUIRED]
+        if effect_field == "z-score":
+            required_fields.remove("standard_error")
         all_headers = [h for h in self.FIELDS_REQUIRED]
+        if effect_field == "z-score":
+            all_headers.remove("standard_error")
         all_headers.extend([h for h in self.FIELDS_OPTIONAL])
         all_headers.extend([h for h in self.FIELDS_EFFECT])
-        header_order = [h for h in self.FIELDS_REQUIRED]
+        header_order = [h for h in required_fields]
         header_order.extend([h for h in self.FIELDS_OPTIONAL if h in self.header()])
         header_order.extend([h for h in self.header() if h not in all_headers])
-        if 'beta' in self.header():
-            header_order.insert(4, 'beta')
-            for h in ('odds_ratio', 'hazard_ratio'):
-                header_order.append(h) if h in self.header() else None
-        elif 'beta' not in self.header() and 'odds_ratio' in self.header():
-            header_order.insert(4, 'odds_ratio')
-            header_order.append('hazard_ratio') if 'hazard_ratio' in self.header() else None
-        elif 'odds_ratio' not in self.header() and 'hazard_ratio' in self.header():
-            header_order.insert(4, 'hazard_ratio')
-        else:
-            pass
+        if effect_field:
+            header_order.insert(4, effect_field)
+            for h in self.FIELDS_EFFECT:
+                if h != effect_field and h in self.header():
+                    header_order.append(h)
         return header_order
 
     def _add_missing_headers(self, missing_headers: set) -> etl.Table:
@@ -237,13 +247,15 @@ class SumStatsTable:
         return field_4
 
     def p_value_field(self) -> Union[str, None]:
-        """Get the p_value field (field index 7).
+        """Get the p_value field.
 
         Returns:
             p_value field label
         """
-        field_4 = self._get_field_label_from_index(7)
-        return field_4
+        for field in self.FIELDS_PVALUE:
+            if field in self.header():
+                return field
+        return None
 
     def _get_field_label_from_index(self, index: int) -> Union[str, None]:
         """Get the field label from specified index

--- a/src/gwas_sumstats_tools/interfaces/data_table.py
+++ b/src/gwas_sumstats_tools/interfaces/data_table.py
@@ -50,6 +50,7 @@ class SumStatsTable:
         missing_headers = self._get_missing_headers()
         if missing_headers:
             self._add_missing_headers(missing_headers)
+        self._normalise_z_score_standard_error()
         header_order = self._set_header_order()
         self.sumstats = etl.cut(self.sumstats, *header_order)
         return self.sumstats
@@ -63,6 +64,7 @@ class SumStatsTable:
         missing_headers = self._get_missing_headers()
         if missing_headers:
             self._add_missing_headers(missing_headers)
+        self._normalise_z_score_standard_error()
         header_order = self._set_header_order()
         self.sumstats = etl.cut(self.sumstats, *header_order)
         return self
@@ -171,13 +173,15 @@ class SumStatsTable:
         Returns:
             set of missing headers
         """
-        required_fields = set(self.FIELDS_REQUIRED)
-        if "z-score" in self.header():
-            required_fields.discard("standard_error")
-        missing_headers = required_fields - set(self.header())
+        missing_headers = set(self.FIELDS_REQUIRED) - set(self.header())
         if set(self.FIELDS_EFFECT).isdisjoint(set(self.header())):
             missing_headers.add("beta")
         return missing_headers
+
+    def _normalise_z_score_standard_error(self) -> etl.Table:
+        if "z-score" in self.header() and "standard_error" in self.header():
+            self.sumstats = etl.convert(self.sumstats, "standard_error", lambda _: "#NA")
+        return self.sumstats
 
     def _effect_field_in_header(self) -> Union[str, None]:
         for field in self.FIELDS_EFFECT:
@@ -193,11 +197,7 @@ class SumStatsTable:
         """
         effect_field = self._effect_field_in_header()
         required_fields = [h for h in self.FIELDS_REQUIRED]
-        if effect_field == "z-score":
-            required_fields.remove("standard_error")
         all_headers = [h for h in self.FIELDS_REQUIRED]
-        if effect_field == "z-score":
-            all_headers.remove("standard_error")
         all_headers.extend([h for h in self.FIELDS_OPTIONAL])
         all_headers.extend([h for h in self.FIELDS_EFFECT])
         header_order = [h for h in required_fields]

--- a/src/gwas_sumstats_tools/schema/data_table.py
+++ b/src/gwas_sumstats_tools/schema/data_table.py
@@ -3,13 +3,13 @@ Pandera Schema https://pandera.readthedocs.io for defining
 the summary statistics data tables. The schema is dynamically
 generated because of columns that can be defined in multiple
 ways e.g. the effect size column (index 4) can be a beta, an
-odds ratio or a hazard ratio - and these all have differing 
+odds ratio, a hazard ratio or a z-score - and these all have differing 
 validation constraints.
 """
 
 from collections import OrderedDict
+import numpy as np
 from pandera import Column, DataFrameSchema, Check
-from pandera.dtypes import Float128
 
 import platform
 
@@ -22,7 +22,7 @@ class SumStatsSchema:
     Choice of standard allowing zero or 
     -log10 allowing zero. The zero constraint
     is applied to the mantissa.
-    The float type is Float128 but even
+    The p-value float type uses numpy.longdouble where available, but even
     this is not precise enough for some
     datasets, whose very small values evaluate
     to 0, if we don't split mantissa and exp.
@@ -36,11 +36,12 @@ class SumStatsSchema:
         "hazard_ratio": Column(float, [
             Check.ge(0,
                      error="Must be a value greater than or equal to 0")
-            ])
+            ]),
+        "z-score": Column(float)
         }
     PVALUE_FIELD_DEFINITIONS = {
         # 'p_value': Column(float, [
-        'p_value': Column(float if platform.system() == "Windows" else Float128, [
+        'p_value': Column(float if platform.system() == "Windows" else np.longdouble, [
             Check.in_range(0, 1,
                            include_min=True,
                            error="Must be a value between 0 and 1, inclusive of 0")
@@ -83,7 +84,7 @@ class SumStatsSchema:
         return schema
 
     def mandatory_fields(self) -> dict:
-        return OrderedDict({
+        fields = OrderedDict({
                 "chromosome": Column(int, [
                     Check.in_range(1, 25,
                                    error="Must be a value between 1 and 25"),
@@ -102,7 +103,10 @@ class SumStatsSchema:
                                       error="Must be nucleotide sequence")
                     ]),
                 self.effect_field: self.EFFECT_FIELD_DEFINITIONS.get(self.effect_field),
-                "standard_error": Column(float),
+            })
+        if self.effect_field != "z-score":
+            fields["standard_error"] = Column(float)
+        fields.update({
                 "effect_allele_frequency": Column(float, [
                     Check.in_range(0, 1,
                                    error="Must be a value between 0 and 1, inclusive")
@@ -111,6 +115,7 @@ class SumStatsSchema:
                 "_p_value_mantissa": self._get_mantissa_validator(),
                 "_p_value_exponent": Column("Int64", nullable=True)           
             })
+        return fields
 
     def field_order(self) -> tuple:
         return tuple(k for k in self.mandatory_fields() if not k.startswith("_"))

--- a/src/gwas_sumstats_tools/schema/data_table.py
+++ b/src/gwas_sumstats_tools/schema/data_table.py
@@ -51,6 +51,13 @@ class SumStatsSchema:
                      error="Must be greater than or equal to 0")
             ])
     }
+    STANDARD_ERROR_DEFINITIONS = {
+        'default': Column(float),
+        'z-score': Column(object, [
+            Check(lambda series: series.isna().all(),
+                  error="Must be #NA for z-score files")
+            ], nullable=True)
+    }
     MANTISSA_VALIDATORS = {
         'default': Column(float, [
             Check.gt(0,
@@ -103,9 +110,8 @@ class SumStatsSchema:
                                       error="Must be nucleotide sequence")
                     ]),
                 self.effect_field: self.EFFECT_FIELD_DEFINITIONS.get(self.effect_field),
+                "standard_error": self._get_standard_error_validator(),
             })
-        if self.effect_field != "z-score":
-            fields["standard_error"] = Column(float)
         fields.update({
                 "effect_allele_frequency": Column(float, [
                     Check.in_range(0, 1,
@@ -156,3 +162,8 @@ class SumStatsSchema:
             return self.MANTISSA_VALIDATORS.get('pval_zero')
         else:
             return self.MANTISSA_VALIDATORS.get('default')
+
+    def _get_standard_error_validator(self) -> Column:
+        if self.effect_field == "z-score":
+            return self.STANDARD_ERROR_DEFINITIONS.get('z-score')
+        return self.STANDARD_ERROR_DEFINITIONS.get('default')

--- a/src/gwas_sumstats_tools/schema/headermap.py
+++ b/src/gwas_sumstats_tools/schema/headermap.py
@@ -255,10 +255,11 @@ known_header_transformations = {
     'Sample-size': 'n',
     'Sample-size-cases': 'n_cas',
     # signed statistics
-    'zscore': 'z',
-    'z-score': 'z',
-    'gc_zscore': 'z',
-    'z': 'z',
+    'zscore': 'z-score',
+    'z_score': 'z-score',
+    'z-score': 'z-score',
+    'gc_zscore': 'z-score',
+    'z': 'z-score',
     'log_odds': 'log_odds',
     'signed_sumstat': 'signed_sumstat',
     # info
@@ -601,10 +602,13 @@ header_mapper = {
 
     # signed statistics
     # =================
-    'z': [
+    'z-score': [
         'zscore',
+        'z_score',
         'z-score',
         'gc_zscore',
-        'z'
+        'z',
+        'Z',
+        'ZSCORE'
         ],
     }

--- a/src/gwas_sumstats_tools/utils.py
+++ b/src/gwas_sumstats_tools/utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import petl as etl
 from requests.adapters import HTTPAdapter, Retry
 import importlib.metadata
+from gwas_sumstats_tools.constants import Z_SCORE_FALLBACK_WARNING
 
 try:
     import typer
@@ -27,6 +28,10 @@ def exit_if_no_data(table: Union[etl.Table, None]) -> None:
     if table is None:
         print("No data in table. Exiting.")
         raise typer.Exit() if typer is not None else SystemExit(1)
+
+
+def warn_z_score_fallback() -> None:
+    print(f"[bold yellow]{Z_SCORE_FALLBACK_WARNING}[/bold yellow]")
 
 
 def parse_accession_id(filename: Path) -> Union[str, None]:

--- a/src/gwas_sumstats_tools/validate.py
+++ b/src/gwas_sumstats_tools/validate.py
@@ -8,6 +8,7 @@ from rich import print
 from gwas_sumstats_tools.schema.data_table import SumStatsSchema
 from gwas_sumstats_tools.interfaces.data_table import SumStatsTable
 from gwas_sumstats_tools.interfaces.metadata import init_metadata_from_file
+from gwas_sumstats_tools.utils import warn_z_score_fallback
 
 
 class Validator(SumStatsTable):
@@ -53,6 +54,8 @@ class Validator(SumStatsTable):
             print("--> [green]Ok[/green]")
             print("Validating column order...")
             self.valid, message = self._validate_field_order()
+            if self.valid and self.effect_field() == "z-score":
+                warn_z_score_fallback()
 
         if self.valid:
             print("--> [green]Ok[/green]")

--- a/tests/interfaces/test_data_table.py
+++ b/tests/interfaces/test_data_table.py
@@ -13,24 +13,28 @@ def sumstats_file():
 
 def test_get_field_label_from_index(mocker):
     headers = ("a", "b", "c", "d", "e", "f")
-    mocker.patch("src.gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
+    mocker.patch("gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
                  return_value=headers)
     assert SumStatsTable("test.tsv")._get_field_label_from_index(4) == headers[4]
     headers = ("a", "b", "c", "d")
-    mocker.patch("src.gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
+    mocker.patch("gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
                  return_value=headers)
     assert SumStatsTable("test.tsv")._get_field_label_from_index(4) is None
 
 
 def test_effect_field(mocker):
     headers = ("a", "b", "c", "d", "e", "f")
-    mocker.patch("src.gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
+    mocker.patch("gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
                  return_value=headers)
     assert SumStatsTable("test.tsv").effect_field() == headers[4]
 
 
 def test_p_value_field(mocker):
-    headers = ("a", "b", "c", "d", "e", "f", "g", "h")
-    mocker.patch("src.gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
+    headers = ("a", "b", "c", "d", "e", "f", "g", "p_value")
+    mocker.patch("gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
                  return_value=headers)
-    assert SumStatsTable("test.tsv").p_value_field() == headers[7]
+    assert SumStatsTable("test.tsv").p_value_field() == "p_value"
+    headers = ("a", "b", "c", "d", "e", "f", "neg_log_10_p_value")
+    mocker.patch("gwas_sumstats_tools.interfaces.data_table.SumStatsTable.header",
+                 return_value=headers)
+    assert SumStatsTable("test.tsv").p_value_field() == "neg_log_10_p_value"

--- a/tests/prep_tests.py
+++ b/tests/prep_tests.py
@@ -32,7 +32,8 @@ TEST_DATA = OrderedDict({
 })
 
 EFFECT_FIELDS = {"odds_ratio": [0.92090, 1.01440, 0.97385, 0.99302] + [0.99301] * 22,
-                 "hazard_ratio": [0.92090, 1.01440, 0.97385, 0.99302] + [0.99301] * 22 }
+                 "hazard_ratio": [0.92090, 1.01440, 0.97385, 0.99302] + [0.99301] * 22,
+                 "z-score": [1.2, -2.4, 0, 3.8] + [-0.5] * 22}
 
 TEST_METADATA = {
     "genotyping_technology": ["Genome-wide genotyping array"],

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -5,6 +5,7 @@ from tests.prep_tests import (SSTestFile,
                               TEST_DATA,
                               MetaTestFile,
                               TEST_METADATA)
+from gwas_sumstats_tools.constants import Z_SCORE_FALLBACK_WARNING
 from gwas_sumstats_tools.format import Formatter
 
 
@@ -90,6 +91,43 @@ class TestFormatter:
             f.data.map_header()
             standard_error_index = f.data.header().index("standard_error")
             assert {row[standard_error_index] for row in list(f.data.sumstats)[1:]} == {"#NA"}
+        finally:
+            sumstats.remove()
+
+    def test_configured_z_score_format_prints_fallback_warning(self, capsys):
+        sumstats = SSTestFile()
+        try:
+            sumstats.replace_header("beta", "zscore")
+            sumstats.test_data.pop("standard_error")
+            sumstats.to_file()
+            config = {
+                "fileConfig": {
+                    "outFilePrefix": None,
+                    "fieldSeparator": "\t",
+                    "naValue": None,
+                    "convertNegLog10Pvalue": False,
+                    "removeComments": None,
+                },
+                "columnConfig": {
+                    "split": [],
+                    "edit": [
+                        {
+                            "field": "zscore",
+                            "rename": "z-score",
+                            "find": None,
+                            "replace": None,
+                            "extract": None,
+                        }
+                    ],
+                },
+            }
+            f = Formatter(sumstats.filepath, config_dict=config)
+            f.test_config()
+            captured = capsys.readouterr().out
+            assert "WARNING: z-score is accepted only as a fallback effect size" in captured
+            assert "beta" in captured
+            assert "odds ratio (OR)" in captured
+            assert "hazard ratio" in captured
         finally:
             sumstats.remove()
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -94,6 +94,29 @@ class TestFormatter:
         finally:
             sumstats.remove()
 
+    def test_map_header_keeps_standard_error_when_beta_present(self):
+        # When a real effect field (beta) is present, z-score is just an extra
+        # column and the genuine standard_error must be preserved, not blanked.
+        sumstats = SSTestFile()
+        try:
+            n_rows = len(sumstats.test_data["beta"])
+            sumstats.test_data["zscore"] = [str(i % 3) for i in range(n_rows)]
+            sumstats.to_file()
+            f = Formatter(sumstats.filepath)
+            f.data.rename_headers({"zscore": "z-score"})
+            f.data.map_header()
+            header = f.data.header()
+            # beta remains the effect field at index 4; z-score appended after.
+            assert header[4] == "beta"
+            assert "z-score" in header
+            assert header.index("z-score") > header.index("standard_error")
+            standard_error_index = header.index("standard_error")
+            se_values = {row[standard_error_index] for row in list(f.data.sumstats)[1:]}
+            assert se_values != {"#NA"}
+            assert "#NA" not in se_values
+        finally:
+            sumstats.remove()
+
     def test_configured_z_score_format_prints_fallback_warning(self, capsys):
         sumstats = SSTestFile()
         try:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -43,4 +43,60 @@ class TestFormatter:
         f = Formatter(sumstats_file, data_outfile="TEST_OUT", format_data=False)
         assert isinstance(f.data_outfile, Path)
         assert str(f.data_outfile) == "TEST_OUT"
+
+    def test_suggest_header_mapping_z_score_alias(self):
+        sumstats = SSTestFile()
+        try:
+            sumstats.replace_header("beta", "zscore")
+            sumstats.test_data.pop("standard_error")
+            sumstats.to_file()
+            f = Formatter(sumstats.filepath)
+            assert f.suggest_header_mapping()["zscore"] == "z-score"
+        finally:
+            sumstats.remove()
+
+    def test_map_header_orders_z_score_without_beta(self):
+        sumstats = SSTestFile()
+        try:
+            sumstats.replace_header("beta", "zscore")
+            sumstats.test_data.pop("standard_error")
+            sumstats.to_file()
+            f = Formatter(sumstats.filepath)
+            f.data.rename_headers({"zscore": "z-score"})
+            f.data.map_header()
+            assert f.data.header()[:7] == (
+                "chromosome",
+                "base_pair_location",
+                "effect_allele",
+                "other_allele",
+                "z-score",
+                "effect_allele_frequency",
+                "p_value",
+            )
+            assert "beta" not in f.data.header()
+            assert "standard_error" not in f.data.header()
+        finally:
+            sumstats.remove()
+
+    def test_pandas_column_order_keeps_z_score_standard_error_as_extra(self):
+        ordered = Formatter._pd_column_order([
+            "chromosome",
+            "base_pair_location",
+            "effect_allele",
+            "other_allele",
+            "z-score",
+            "standard_error",
+            "effect_allele_frequency",
+            "p_value",
+        ])
+        assert ordered[:7] == [
+            "chromosome",
+            "base_pair_location",
+            "effect_allele",
+            "other_allele",
+            "z-score",
+            "effect_allele_frequency",
+            "p_value",
+        ]
+        assert ordered[7] == "standard_error"
         

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -70,15 +70,30 @@ class TestFormatter:
                 "effect_allele",
                 "other_allele",
                 "z-score",
+                "standard_error",
                 "effect_allele_frequency",
-                "p_value",
             )
+            assert f.data.header()[7] == "p_value"
+            standard_error_index = f.data.header().index("standard_error")
+            assert {row[standard_error_index] for row in list(f.data.sumstats)[1:]} == {"#NA"}
             assert "beta" not in f.data.header()
-            assert "standard_error" not in f.data.header()
         finally:
             sumstats.remove()
 
-    def test_pandas_column_order_keeps_z_score_standard_error_as_extra(self):
+    def test_map_header_overwrites_z_score_standard_error(self):
+        sumstats = SSTestFile()
+        try:
+            sumstats.replace_header("beta", "zscore")
+            sumstats.to_file()
+            f = Formatter(sumstats.filepath)
+            f.data.rename_headers({"zscore": "z-score"})
+            f.data.map_header()
+            standard_error_index = f.data.header().index("standard_error")
+            assert {row[standard_error_index] for row in list(f.data.sumstats)[1:]} == {"#NA"}
+        finally:
+            sumstats.remove()
+
+    def test_pandas_column_order_keeps_z_score_standard_error_in_standard_position(self):
         ordered = Formatter._pd_column_order([
             "chromosome",
             "base_pair_location",
@@ -95,8 +110,8 @@ class TestFormatter:
             "effect_allele",
             "other_allele",
             "z-score",
+            "standard_error",
             "effect_allele_frequency",
-            "p_value",
         ]
-        assert ordered[7] == "standard_error"
+        assert ordered[7] == "p_value"
         

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -178,6 +178,58 @@ class TestValidator:
         assert v._validate_field_order()[0] is True
         assert v.validate()[0] is True
 
+    def test_validate_z_score_instead_of_beta(self, sumstats_file):
+        sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
+                                              "beta",
+                                              "z-score")
+        sumstats_file.test_data.pop("standard_error")
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v._validate_field_order()[0] is True
+        assert v.validate()[0] is True
+
+    def test_validate_z_score_with_standard_error_in_mandatory_position(self, sumstats_file):
+        sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
+                                              "beta",
+                                              "z-score")
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v.validate()[0] is False
+        assert v.primary_error_type == "field order"
+
+    def test_validate_z_score_with_standard_error_as_extra_field(self, sumstats_file):
+        sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
+                                              "beta",
+                                              "z-score")
+        standard_error = sumstats_file.test_data.pop("standard_error")
+        sumstats_file.test_data["standard_error"] = standard_error
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v._validate_field_order()[0] is True
+        assert v.validate()[0] is True
+
+    def test_validate_invalid_z_score(self, sumstats_file):
+        sumstats_file.replace_header_and_data(["str", None, "a", "b"] + [1] * 22,
+                                              "beta",
+                                              "z-score")
+        sumstats_file.test_data.pop("standard_error")
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v.validate()[0] is False
+        assert v.primary_error_type == "data"
+
+    def test_validate_z_score_neg_log_pvalue(self, sumstats_file):
+        sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
+                                              "beta",
+                                              "z-score")
+        sumstats_file.test_data.pop("standard_error")
+        sumstats_file.replace_header_and_data(header_from="p_value",
+                                              header_to="neg_log_10_p_value",
+                                              data_to=[10, 2, 3, 4] + [i for i in range(1,23)])
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v.validate()[0] is True
+
     def test_validate_mandatory_field_missing(self, sumstats_file):
         sumstats_file.test_data.pop("chromosome")
         sumstats_file.to_file()
@@ -187,6 +239,13 @@ class TestValidator:
 
     def test_validate_p_value_field_missing(self, sumstats_file):
         sumstats_file.test_data.pop("p_value")
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v.validate()[0] is False
+        assert v.primary_error_type == "field order"
+
+    def test_validate_non_z_score_standard_error_missing(self, sumstats_file):
+        sumstats_file.test_data.pop("standard_error")
         sumstats_file.to_file()
         v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
         assert v.validate()[0] is False

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -182,37 +182,36 @@ class TestValidator:
         sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
                                               "beta",
                                               "z-score")
-        sumstats_file.test_data.pop("standard_error")
+        sumstats_file.replace_values("standard_error", ["#NA"] * len(EFFECT_FIELDS["z-score"]))
         sumstats_file.to_file()
         v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
         assert v._validate_field_order()[0] is True
         assert v.validate()[0] is True
 
-    def test_validate_z_score_with_standard_error_in_mandatory_position(self, sumstats_file):
+    def test_validate_z_score_with_numeric_standard_error(self, sumstats_file):
         sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
                                               "beta",
                                               "z-score")
         sumstats_file.to_file()
         v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
         assert v.validate()[0] is False
-        assert v.primary_error_type == "field order"
+        assert v.primary_error_type == "data"
 
-    def test_validate_z_score_with_standard_error_as_extra_field(self, sumstats_file):
+    def test_validate_z_score_missing_standard_error(self, sumstats_file):
         sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
                                               "beta",
                                               "z-score")
-        standard_error = sumstats_file.test_data.pop("standard_error")
-        sumstats_file.test_data["standard_error"] = standard_error
+        sumstats_file.test_data.pop("standard_error")
         sumstats_file.to_file()
         v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
-        assert v._validate_field_order()[0] is True
-        assert v.validate()[0] is True
+        assert v.validate()[0] is False
+        assert v.primary_error_type == "field order"
 
     def test_validate_invalid_z_score(self, sumstats_file):
         sumstats_file.replace_header_and_data(["str", None, "a", "b"] + [1] * 22,
                                               "beta",
                                               "z-score")
-        sumstats_file.test_data.pop("standard_error")
+        sumstats_file.replace_values("standard_error", ["#NA"] * len(EFFECT_FIELDS["z-score"]))
         sumstats_file.to_file()
         v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
         assert v.validate()[0] is False
@@ -222,7 +221,7 @@ class TestValidator:
         sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
                                               "beta",
                                               "z-score")
-        sumstats_file.test_data.pop("standard_error")
+        sumstats_file.replace_values("standard_error", ["#NA"] * len(EFFECT_FIELDS["z-score"]))
         sumstats_file.replace_header_and_data(header_from="p_value",
                                               header_to="neg_log_10_p_value",
                                               data_to=[10, 2, 3, 4] + [i for i in range(1,23)])

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,6 +4,7 @@ import petl as etl
 from tests.prep_tests import SSTestFile, EFFECT_FIELDS
 from pandera import DataFrameSchema
 
+from gwas_sumstats_tools.constants import Z_SCORE_FALLBACK_WARNING
 from gwas_sumstats_tools.validate import Validator
 
 
@@ -187,6 +188,29 @@ class TestValidator:
         v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
         assert v._validate_field_order()[0] is True
         assert v.validate()[0] is True
+
+    def test_validate_z_score_prints_fallback_warning(self, sumstats_file, capsys):
+        sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],
+                                              "beta",
+                                              "z-score")
+        sumstats_file.replace_values("standard_error", ["#NA"] * len(EFFECT_FIELDS["z-score"]))
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v.validate()[0] is True
+        captured = capsys.readouterr().out
+        assert "WARNING: z-score is accepted only as a fallback effect size" in captured
+        assert "beta" in captured
+        assert "odds ratio (OR)" in captured
+        assert "hazard ratio" in captured
+
+    def test_validate_non_z_score_does_not_print_fallback_warning(self, sumstats_file, capsys):
+        sumstats_file.replace_header_and_data(EFFECT_FIELDS["odds_ratio"],
+                                              "beta",
+                                              "odds_ratio")
+        sumstats_file.to_file()
+        v = Validator(sumstats_file=sumstats_file.filepath, minimum_rows=4)
+        assert v.validate()[0] is True
+        assert Z_SCORE_FALLBACK_WARNING not in capsys.readouterr().out
 
     def test_validate_z_score_with_numeric_standard_error(self, sumstats_file):
         sumstats_file.replace_header_and_data(EFFECT_FIELDS["z-score"],


### PR DESCRIPTION
Sometimes people do meta-analysis where the only output metric is z-score.

In this case standard error will always be missing.

Adds support for z-score as an effect size type. 

Closes https://github.com/EBISPOT/goci/issues/1911