### PR TITLE
Remove upper version constraint in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "gwas_sumstats_tools"}]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.9"
 petl = "^1.7.12"
 requests = "^2.28.2"
 pyyaml = "^6.0"


### PR DESCRIPTION
It is usually strongly discouraged because of exactly this slow implicit deprecation of packages:
https://iscinumpy.dev/post/bound-version-constraints/

Currently makes the library almost unusable because 3.11 is the only supported version that is not soon deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Python version compatibility to support Python 3.12 and later versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->